### PR TITLE
Fixed conflict with Laravel Debugbar

### DIFF
--- a/src/Http/Controllers/EventsController.php
+++ b/src/Http/Controllers/EventsController.php
@@ -10,10 +10,9 @@ class EventsController
     public function index(Request $request)
     {
         $events = Event::filter($request->query())
-            ->get(['id', 'title', 'start', 'end'])
-            ->toJson();
+            ->get(['id', 'title', 'start', 'end']);
 
-        return response($events);
+        return response()->json($events);
     }
 
     public function store(Request $request)


### PR DESCRIPTION
This PR fixes an issue (as seen on #4) where Laravel Debugbar forces it's code in to the Calendar `index()` response. 

By properly returning the response using `response()->json()` we eliminate the issue.  